### PR TITLE
UX: convert message to chat

### DIFF
--- a/utils/items.cfg
+++ b/utils/items.cfg
@@ -259,10 +259,10 @@ weapon #endarg
         [/insert_tag])
         TYPE={TYPE}}
 
-        [message]
-            speaker = narrator
+        [chat]
+            speaker = "WISh"
             message = "Item Dropped!"
-        [/message]
+        [/chat]
     [/then]
 [/if]
 #enddef


### PR DESCRIPTION
UX: it's better to have shown up on chat log then as a message. To avoid the message being spammed if multiple items are dropped during one turn (when all your goblins with items are dying...)